### PR TITLE
Link against libplatform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_circular(resolv-darwin FAT
 		system_notify
 		system_configuration
 		system_dyld
+		platform
 )
 set_target_properties(resolv-darwin PROPERTIES OUTPUT_NAME "resolv.9")
 


### PR DESCRIPTION
When building darling with `-O2`, the build fails since it fails to find a symbol called `__bzero` that the optimiser converted memset into.  This fixes that. Similar to <https://github.com/darlinghq/darling-removefile/pull/3>.